### PR TITLE
Update instructions in readme for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ FlavinDB
     * `source venv/bin/activate`
 3. Install the requirements
     * `pip3 install -r requirements.txt`
-    * NOTE for OS X users: install `libpng` and `freetype` via brew if you get a `Command "python setup.py egg_info" failed with error code 1` error when trying to install matplotlib. See http://stackoverflow.com/questions/9829175/pip-install-matplotlib-error-with-virtualenv for more details.
+    * NOTE for OS X users: install `libpng` and `freetype` via brew if you get a `Command "python setup.py egg_info" failed with error code 1` error when trying to install matplotlib. See [here](http://stackoverflow.com/questions/9829175/pip-install-matplotlib-error-with-virtualenv) for more details.


### PR DESCRIPTION
Just some small fixes. Corrected the brew formula from `brew install python3.6` to `brew install python3` and changed the pip commands to ensure that pip for Python 3.6 will be used if multiple versions of python exist on the host machine (don't think it should matter when installing virtualenv but changed it just to be safe). 